### PR TITLE
fix: assign null for empty wp meta info

### DIFF
--- a/lib/src/schemas/post.g.dart
+++ b/lib/src/schemas/post.g.dart
@@ -29,7 +29,8 @@ PostSchema _$PostSchemaFromJson(Map<String, dynamic> json) {
     commentStatus: json['comment_status'] as String,
     pingStatus: json['ping_status'] as String,
     format: json['format'] as String,
-    meta: json['meta'] as Map<String, dynamic>,
+    meta:
+        json['meta'].length == 0 ? null : json['meta'] as Map<String, dynamic>,
     sticky: json['sticky'] as bool,
     template: json['template'] as String,
     categories: json['categories'] as List,


### PR DESCRIPTION
fixes #8 
WP meta info is empty array when posts meta is not present. Assigned as null when meta is empty.