### PR TITLE
Added the possibility to customize Dio parameters

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -142,7 +142,7 @@ class WordPressAPI {
   /// WordPress website
   String site;
   String _namespace = wpNamespace;
-  final Dio _dio = Dio();
+  final Dio _dio;
 
   /// WooCommerce API credentials
   final WooCredentials wooCredentials;
@@ -150,10 +150,7 @@ class WordPressAPI {
   // **********************************************
   // INITIALIZATION
   // **********************************************
-  WordPressAPI(
-    this.site, {
-    this.wooCredentials,
-  });
+  WordPressAPI(this.site, {this.wooCredentials, Dio dio}) : _dio = dio ?? Dio();
 
   // **********************************************
   // DISCOVER API LINK FROM HEADERS //


### PR DESCRIPTION
But once, thanks for this beautiful package, it saves my time and I would like to contribute!

The possibility of starting Dio with custom parameters is very important, because there are several packages that add incredible functionality to Dio (dio_http_cache) some are listed on the pub.dev/dio page.

So I added the possibility and I'm requesting this pull...

This way we can customize the initializer
```dart
final BaseOptions options = BaseOptions(
    connectTimeout: 5000,
    receiveTimeout: 10000,
  );

final wp = WordPressAPI('kellvem.pt', dio: Dio(options));
```

If you do not want this we can also start in the original way made by you!
```dart
final wp = WordPressAPI('kellvem.pt');
```

So it's up to the user to use it :))
